### PR TITLE
Fix stack corruption bug in format and some compiler warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### 1. Add to your project
 
-Simply include the `heapstat.hh` header file in whichever source files you want to track for heap allocation or deallocation issues, and add the `heapstat.cc` file to your project and your build target(s).
+Simply include the `heapstat.h` header file in whichever source files you want to track for heap allocation or deallocation issues, and add the `heapstat.cc` file to your project and your build target(s).
 
 All calls to the default heap allocators are automatically intercepted. Heapstat works with:
 - `malloc`
@@ -28,7 +28,7 @@ Call the function `heapstat()` at any time to print out a summary of heap pointe
 ## Example (heapstat_test.cc)
 
 ```cpp
-#include "heapstat.hh"
+#include "heapstat.h"
 
 int main()
 {

--- a/heapstat.cc
+++ b/heapstat.cc
@@ -144,3 +144,11 @@ void* operator new[](size_t size, const char* desc)
 }
 void operator delete(void* ptr) throw() { heapstat_free(ptr, "<unknown>"); }
 void operator delete[](void* ptr) throw() { heapstat_free(ptr, "<unknown>"); }
+void operator delete(void* ptr, const char* desc) throw()
+{
+  heapstat_free(ptr, desc);
+}
+void operator delete[](void* ptr, const char* desc) throw()
+{
+  heapstat_free(ptr, desc);
+}

--- a/heapstat.h
+++ b/heapstat.h
@@ -28,6 +28,8 @@ size_t heapstat();
 #define free(ptr) heapstat_free((ptr), SPOT(__FILE__, __LINE__));
 void* operator new(size_t size, const char* desc);
 void* operator new[](size_t size, const char* desc);
+void operator delete(void* ptr, const char* desc) throw();
+void operator delete[](void* ptr, const char* desc) throw();
 void operator delete(void* ptr) throw();
 void operator delete[](void* ptr) throw();
 #define new new (SPOT(__FILE__, __LINE__))

--- a/heapstat.h
+++ b/heapstat.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------
 // HOW TO USE HEAPSTAT:
-// 1. include the header "heapstat.hh"
+// 1. include the header "heapstat.h"
 // 2. add the file "heapstat.cc" to your C++ project and build targets
 // 3. Just call heapstat() whenever you want to check for leaks
 //    - returns (size_t): total bytes leaked over all allocations so far


### PR DESCRIPTION
When a 3 digit number is passed to format(), it tries to prepend a
digit separator ‘'’ to the buffer leading to a stack corruption by
writing to buf[-1].  Fix this by adding an additional check.

As per the C++ language standard ([1]), every placement new should
have a matching a placement delete with the same parameters.  Without
them VC++ warns

> warning C4291: 'void *operator new(size_t,const char *)': no
> matching operator delete found; memory will not be freed if
> initialization throws an exception

[1]: https://en.cppreference.com/w/cpp/memory/new/operator_delete